### PR TITLE
startDiscovery with android 10

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,6 +37,7 @@
 			<uses-permission android:name="android.permission.BLUETOOTH" />
 			<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 			<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 		</config-file>
 		<source-file src="src/android/NetworkingBluetooth.java" target-dir="src/cordova/plugin/networking/bluetooth" />
 	</platform>

--- a/src/android/NetworkingBluetooth.java
+++ b/src/android/NetworkingBluetooth.java
@@ -206,11 +206,12 @@ public class NetworkingBluetooth extends CordovaPlugin {
 			if (this.mBluetoothAdapter.isDiscovering()) {
 				this.mBluetoothAdapter.cancelDiscovery();
 			}
-
-			if (cordova.hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)) {
-				this.startDiscovery(callbackContext);
-			} else {
+			if (!cordova.hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)) {
 				this.getPermission(callbackContext, START_DISCOVERY_REQ_CODE, Manifest.permission.ACCESS_COARSE_LOCATION);
+			} else if (!cordova.hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)) {
+				this.getPermission(callbackContext, START_DISCOVERY_REQ_CODE, Manifest.permission.ACCESS_FINE_LOCATION);
+			} else {
+				this.startDiscovery(callbackContext);
 			}
 			return true;
 		} else if (action.equals("stopDiscovery")) {


### PR DESCRIPTION
The following function doesn't work anymore on Android 10 : networking.bluetooth.startDiscovery

See : https://stackoverflow.com/questions/61792203/bluetooth-startdiscovery-is-not-working-on-android-10

